### PR TITLE
Js_browser: added bindings for Date

### DIFF
--- a/lib/js_browser.mli
+++ b/lib/js_browser.mli
@@ -17,6 +17,61 @@ module Storage : sig
   val clear: t -> unit
 end
 
+module Date : sig
+  type t = private Ojs.t
+  val t_of_js: Ojs.t -> t
+  val t_to_js: t -> Ojs.t
+
+  val new_date: float -> t [@@js.new]
+  val now : unit -> float [@@js.global "Date.now"]
+  val parse : string -> t [@@js.global "Date.parse"]
+
+  val get_date : t -> int [@@js.call]
+  val get_day : t -> int [@@js.call]
+  val get_full_year : t -> int [@@js.call]
+  val get_hours : t -> int [@@js.call]
+  val get_milliseconds : t -> int [@@js.call]
+  val get_minutes : t -> int [@@js.call]
+  val get_month : t -> int [@@js.call]
+  val get_seconds : t -> int [@@js.call]
+  val get_time : t -> int [@@js.call]
+  val get_timezone_offset : t -> int [@@js.call]
+  val get_UTC_date : t -> int [@@js.call]
+  val get_UTC_day : t -> int [@@js.call]
+  val get_UTC_full_year : t -> int [@@js.call]
+  val get_UTC_hours : t -> int [@@js.call]
+  val get_UTC_milliseconds : t -> int [@@js.call]
+  val get_UTC_minutes : t -> int [@@js.call]
+  val get_UTC_month : t -> int [@@js.call]
+  val get_UTC_seconds : t -> int [@@js.call]
+  val get_year : t -> int [@@js.call]
+
+  val set_date : t -> int -> unit [@@js.call]
+  val set_full_year : t -> int -> unit [@@js.call]
+  val set_hours : t -> int -> unit [@@js.call]
+  val set_milliseconds : t -> int -> unit [@@js.call]
+  val set_minutes : t -> int -> unit [@@js.call]
+  val set_month : t -> int -> unit [@@js.call]
+  val set_seconds : t -> int -> unit [@@js.call]
+  val set_time : t -> int -> unit [@@js.call]
+  val set_UTC_date : t -> int -> unit [@@js.call]
+  val set_UTC_full_year : t -> int -> unit [@@js.call]
+  val set_UTC_hours : t -> int -> unit [@@js.call]
+  val set_UTC_milliseconds : t -> int -> unit [@@js.call]
+  val set_UTC_minutes : t -> int -> unit [@@js.call]
+  val set_UTC_month : t -> int -> unit [@@js.call]
+  val set_UTC_seconds : t -> int -> unit [@@js.call]
+  val set_year : t -> int -> unit [@@js.call]
+
+  val to_date_string : t -> string [@@js.call]
+  val to_GMT_string : t -> string [@@js.call]
+  val to_ISO_string : t -> string [@@js.call]
+  val to_locale_string : t -> string [@@js.call]
+  val to_string : t -> string [@@js.call]
+  val to_time_string : t -> string [@@js.call]
+  val to_UTC_string : t -> string [@@js.call]
+end
+
 module File : sig
   type t = private Ojs.t
   val t_of_js: Ojs.t -> t


### PR DESCRIPTION
This commit adds support for the [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object. The bindings have been tested (though not systematically for all functions). Maybe there is a way to have less annotations, I can change that if required.