### PR TITLE
click/dblclick handlers take a mouse_event argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Next release
 ============
 
 - GPR#14: delay rendering (view + DOM updates) with requestAnimationFrame
+- GPR#15: click/dblclick handlers take a mouse_event argument (API change)
 - GPR#16: improve support for checkboxes
 
 0.1

--- a/examples/counters.ml
+++ b/examples/counters.ml
@@ -18,7 +18,7 @@ let update { counters } = function
 
 let init = { counters = IntMap.empty }
 
-let button txt msg = input [] ~a:[onclick msg; type_button; value txt]
+let button txt msg = input [] ~a:[onclick (fun _ -> msg); type_button; value txt]
 
 let view { counters } =
   let row (pos, value) =

--- a/examples/date.ml
+++ b/examples/date.ml
@@ -19,7 +19,7 @@ let view n =
       div [text (Printf.sprintf "Number of milliseconds: %f" n)];
       div [text (Printf.sprintf "ToDateString: %s" (Js_browser.Date.to_date_string t))];
       div [text (Printf.sprintf "ToLocaleString: %s" (Js_browser.Date.to_locale_string t))];
-      div [input [] ~a:[onclick `Click; type_button; value "Update"]]
+      div [input [] ~a:[onclick (fun _ -> `Click); type_button; value "Update"]]
     ]
 
 let app = simple_app ~init ~view ~update ()

--- a/examples/demo.ml
+++ b/examples/demo.ml
@@ -15,7 +15,7 @@ let http_get ~url ~payload on_success = Http_get {url; payload; on_success}
 let after x f = After (x, f)
 
 
-let button ?(a = []) txt f = input [] ~a:(onclick f :: type_button :: value txt :: a)
+let button ?(a = []) txt f = input [] ~a:(onclick (fun _ -> f) :: type_button :: value txt :: a)
 let br = elt "br" []
 
 
@@ -245,7 +245,7 @@ module Talk1 = struct
 
   let button txt msg =
     elt "input" []
-      ~a:[onclick msg; str_prop "type" "button";
+      ~a:[onclick (fun _ -> msg); str_prop "type" "button";
           str_prop "value" txt;
          ]
 

--- a/examples/demo.ml
+++ b/examples/demo.ml
@@ -324,17 +324,17 @@ module DemoCheckbox = struct
         elt "input" []
           ~a:[str_prop "type" "checkbox";
               bool_prop "checked" checked;
-              onclick `Click1;
+              onclick (fun _ -> `Click1);
              ];
         elt "input" []
           ~a:[str_prop "type" "checkbox";
               bool_prop "checked" checked;
-              onclick `Click1;
+              onclick (fun _ -> `Click1);
              ];
         elt "input" []
           ~a:[str_prop "type" "checkbox";
               bool_prop "checked" (not checked);
-              onclick `Click1;
+              onclick (fun _ -> `Click1);
              ];
         elt "input" []
           ~a:[str_prop "type" "checkbox";

--- a/examples/svg.ml
+++ b/examples/svg.ml
@@ -23,7 +23,7 @@ let view n =
         [
           svg_elt "circle" []
             ~a:[
-              onclick `Click;
+              onclick (fun _ -> `Click);
               int_attr "cx" (n * 10);
               int_attr "cy" (n * 10);
               int_attr "r" (n * 10);

--- a/examples/vdom_ui.ml
+++ b/examples/vdom_ui.ml
@@ -35,7 +35,7 @@ module SelectionList = struct
                [style "background-color" "#E0E0E0";
                 scroll_to_show] else [] in
            div
-             ~a:(onclick (select x) :: class_ "link" :: a)
+             ~a:(onclick (fun _ -> select x) :: class_ "link" :: a)
              [ text (show x) ]
         )
         instrs

--- a/lib/vdom.ml
+++ b/lib/vdom.ml
@@ -23,8 +23,8 @@ type mouse_event = {x: int; y: int; buttons: int}
 type key_event = {which: int}
 
 type 'msg event_handler =
-  | Click of 'msg
-  | DblClick of 'msg
+  | Click of (mouse_event -> 'msg)
+  | DblClick of (mouse_event -> 'msg)
   | Focus of 'msg
   | Blur of 'msg
   | Input of (string -> 'msg)

--- a/lib/vdom.mli
+++ b/lib/vdom.mli
@@ -59,8 +59,8 @@ type mouse_event = {x: int; y: int; buttons: int}
 type key_event = {which: int}
 
 type 'msg event_handler =
-  | Click of 'msg
-  | DblClick of 'msg
+  | Click of (mouse_event -> 'msg)
+  | DblClick of (mouse_event -> 'msg)
   | Focus of 'msg
   | Blur of 'msg
   | Input of (string -> 'msg)
@@ -87,8 +87,8 @@ type 'msg attribute =
 
 (** {3 Event handlers} *)
 
-val onclick: 'msg -> 'msg attribute
-val ondblclick: 'msg -> 'msg attribute
+val onclick: (mouse_event -> 'msg) -> 'msg attribute
+val ondblclick: (mouse_event -> 'msg) -> 'msg attribute
 val onfocus: 'msg -> 'msg attribute
 val onblur: 'msg -> 'msg attribute
 val oninput: (string -> 'msg) -> 'msg attribute

--- a/lib/vdom_blit.ml
+++ b/lib/vdom_blit.ml
@@ -531,8 +531,8 @@ let run (type msg) (type model) ?(env = empty)
             | "change", Handler (Change f) :: _-> Some (f (Element.value tgt))
             | "change", Handler (ChangeIndex f) :: _-> Some (f (Element.selected_index tgt))
             | "change", Handler (ChangeChecked f) :: _-> Some (f (Element.checked tgt))
-            | "click", Handler (Click msg) :: _ -> Some msg
-            | "dblclick", Handler (DblClick msg) :: _ -> Some msg
+            | "click", Handler (Click f) :: _ -> Some (f (mouse_event evt))
+            | "dblclick", Handler (DblClick f) :: _ -> Some (f (mouse_event evt))
             | "blur", Handler (Blur msg) :: _-> Some msg
             | "focus", Handler (Focus msg) :: _ -> Some msg
             | "mousemove", Handler (MouseMove f) :: _ -> Some (f (mouse_event evt))


### PR DESCRIPTION
Fix #11.

This breaks the API.  One could avoid it by introducing new variants of `Vdom.onclick/ondblclick`, but I don't feel this is necessary (we are at version 0.1 for a reason).
