### PR TITLE
Propagate DOM events upwards until finding a handler.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Next release
 - GPR#14: delay rendering (view + DOM updates) with requestAnimationFrame
 - GPR#15: click/dblclick handlers take a mouse_event argument (API change)
 - GPR#16: improve support for checkboxes
+- GPR#18: propagate DOM events upwards until finding a handler
 
 0.1
 ===

--- a/examples/demo.ml
+++ b/examples/demo.ml
@@ -358,6 +358,36 @@ module DemoCheckbox = struct
 end
 
 
+module Issue18_propagation = struct
+  open Vdom
+
+  type model = Unclicked | Clicked of string
+
+  type message = Click of string | Reset
+
+  let view =
+    function
+    | Unclicked ->
+        div ~a:[onclick (fun _ -> Click "outer"); class_ "outer"]
+          [
+            div ~a:[ class_ "inner"] [text "inside the inner div"];
+            div ~a:[ class_ "inner"; onclick (fun _ -> Click "inner")]
+              [text "inner div with own click handler"];
+            text "outside the inner div";
+          ]
+    | Clicked s ->
+        div ~a:[onclick (fun _ -> Reset)] [text (Printf.sprintf "Clicked: %s" s)]
+
+  let init = Unclicked
+
+  let update _m = function
+    | Click s -> Clicked s
+    | Reset -> Unclicked
+
+  let app = simple_app ~init ~view ~update ()
+
+end
+
 (* Custom command handlers *)
 
 let run_http_get ~url ~payload ~on_success () =
@@ -403,6 +433,7 @@ let run () =
   r MouseMove.app;
   r DemoSelection.app;
   r DemoCheckbox.app;
+  r Issue18_propagation.app;
   ()
 
 let () = Window.set_onload window run


### PR DESCRIPTION
Fix #18.

Previously, only handlers on the event target itself were applied.  Now
if the target does not defines a handler, the search continues with its
parent, up to the root.

It's not clear whether it makes sense to propagate all events (for instance, input/change
might not be relevant).