### PR TITLE
Add bindings for WebSockets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Next release
 - GPR#15: click/dblclick handlers take a mouse_event argument (API change)
 - GPR#16: improve support for checkboxes
 - GPR#18: propagate DOM events upwards until finding a handler
+- GPR#21: bindings for WebSockets (contributed by Levi Roth)
 
 0.1
 ===

--- a/lib/js_browser.mli
+++ b/lib/js_browser.mli
@@ -394,6 +394,35 @@ module XHR: sig
   val set_onreadystatechange: t -> (unit -> unit) -> unit
 end
 
+module WebSocket : sig
+  type t
+  val t_of_js: Ojs.t -> t
+  val t_to_js: t -> Ojs.t
+
+  type ready_state =
+    | Connecting [@js 0]
+    | Open [@js 1]
+    | Closing [@js 2]
+    | Closed [@js 3]
+  [@@js.enum]
+
+  val create : string -> ?protocols:string list -> unit -> t [@@js.new "WebSocket"]
+  val send : t -> string -> unit
+  val close : t -> ?code:int -> ?reason:string -> unit -> unit
+
+  val binary_type : t -> string
+  val set_binary_type : t -> string -> unit
+  val ready_state : t -> ready_state
+
+  val add_event_listener: t -> string -> (Event.t -> unit) -> bool -> unit
+
+  module CloseEvent : sig
+    type t = Event.t
+
+    val code : t -> int
+  end
+end
+
 val window: Window.t
 val document: Document.t
 


### PR DESCRIPTION
This PR adds bindings for WebSockets.

One thing that's missing is support for `CloseEvent`, which adds a `code` attribute to the normal attributes of an event. I wasn't sure if there's an easy way to include the interface for `Event`.