### PR TITLE
Make the vdom type covariant in the 'msg parameter

### DIFF
--- a/lib/vdom.ml
+++ b/lib/vdom.ml
@@ -75,7 +75,7 @@ let type_button = type_ "button"
 let value x = Property ("value", String x)
 let disabled x = Property ("disabled", Bool x)
 
-type 'msg vdom =
+type +'msg vdom =
   | Text of
       {
         key: string;

--- a/lib/vdom.mli
+++ b/lib/vdom.mli
@@ -153,7 +153,7 @@ val input_event: string -> event
 (** {2 VDOM} *)
 
 
-type 'msg vdom =
+type +'msg vdom =
   | Text of
       {
         key: string;


### PR DESCRIPTION
This allows the relaxed value restriction to kick in, for example when writing:

    let hr = elt "hr" []

Which is now given the type 'a vdom (previously it was given a weakly polymorphic type).