### PR TITLE
Disposing custom elements

### DIFF
--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -420,11 +420,25 @@ let cmd_handler ctx = function
 
 let () = Vdom_blit.(register (cmd {f = cmd_handler}))
 
+let test_dispose = true
 
 let run () =
+  let body = Document.body document in
   let r app =
-    Vdom_blit.run app |> Vdom_blit.dom |> Element.append_child (Document.body document);
-    Element.append_child (Document.body document) (Document.create_element document "hr")
+    let container = Document.create_element document "div" in
+    let app = Vdom_blit.run ~container app in
+    Element.append_child body container;
+    if test_dispose then begin
+      let button = Document.create_element document "button" in
+      Element.append_child button (Document.create_text_node document "Dispose Application");
+      Element.add_event_listener button Event.Click (fun _ ->
+          Element.remove button;
+          Vdom_blit.dispose app;
+          Element.append_child container (Document.create_text_node document "Disposed");
+        ) false;
+      Element.append_child body button;
+    end;
+    Element.append_child body (Document.create_element document "hr");
   in
 
   r Talk1.app;

--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -405,7 +405,7 @@ let run_http_get ~url ~payload ~on_success () =
        | Done -> on_success (response_text r)
        | _ ->
            ()
-      );
+    );
   send r (Ojs.string_to_js payload)
 
 let cmd_handler ctx = function

--- a/examples/demo/vdom_ui.mli
+++ b/examples/demo/vdom_ui.mli
@@ -27,7 +27,7 @@ module Initializable : sig
     unit ->
     ('a model, ('a, 'msg) msg) Vdom.app
 
-   (* Wrap an application that requires an initialization step to get
-      its initial state (generated as the outcome of a command). The wrapper
-      shows a wait message as long as the initial state is not available. *)
+  (* Wrap an application that requires an initialization step to get
+     its initial state (generated as the outcome of a command). The wrapper
+     shows a wait message as long as the initial state is not available. *)
 end

--- a/examples/tippy/bindings/dune
+++ b/examples/tippy/bindings/dune
@@ -1,7 +1,8 @@
 (rule
-  (targets tippy.ml)
-  (deps tippy.mli)
-  (action (run %{bin:gen_js_api} %{deps})))
+ (targets tippy.ml)
+ (deps tippy.mli)
+ (action
+  (run %{bin:gen_js_api} %{deps})))
 
 (library
  (name bindings)

--- a/examples/tippy/bindings/dune
+++ b/examples/tippy/bindings/dune
@@ -1,0 +1,10 @@
+(rule
+  (targets tippy.ml)
+  (deps tippy.mli)
+  (action (run %{bin:gen_js_api} %{deps})))
+
+(library
+ (name bindings)
+ (libraries gen_js_api ocaml-vdom)
+ (modes byte)
+ (js_of_ocaml))

--- a/examples/tippy/bindings/tippy.mli
+++ b/examples/tippy/bindings/tippy.mli
@@ -1,0 +1,22 @@
+
+type t
+
+val t_of_js: Ojs.t -> t
+val t_to_js: t -> Ojs.t
+
+type props = {
+  trigger: string option;
+}
+
+type options = {
+  content: string;
+  trigger: string option;
+}
+
+val create: Js_browser.Element.t -> options -> t
+[@@js.global "tippy"]
+
+val set_content: t -> string -> unit [@@js.call "setContent"]
+val set_props: t -> props -> unit [@@js.call "setProps"]
+
+val destroy: t -> unit

--- a/examples/tippy/bindings/tippy.mli
+++ b/examples/tippy/bindings/tippy.mli
@@ -1,22 +1,17 @@
-
 type t
 
-val t_of_js: Ojs.t -> t
-val t_to_js: t -> Ojs.t
+val t_of_js : Ojs.t -> t
 
-type props = {
-  trigger: string option;
-}
+val t_to_js : t -> Ojs.t
 
-type options = {
-  content: string;
-  trigger: string option;
-}
+type props = { trigger: string option }
 
-val create: Js_browser.Element.t -> options -> t
-[@@js.global "tippy"]
+type options = { content: string; trigger: string option }
 
-val set_content: t -> string -> unit [@@js.call "setContent"]
-val set_props: t -> props -> unit [@@js.call "setProps"]
+val create : Js_browser.Element.t -> options -> t [@@js.global "tippy"]
 
-val destroy: t -> unit
+val set_content : t -> string -> unit [@@js.call "setContent"]
+
+val set_props : t -> props -> unit [@@js.call "setProps"]
+
+val destroy : t -> unit

--- a/examples/tippy/dune
+++ b/examples/tippy/dune
@@ -1,0 +1,15 @@
+(executable
+ (name main)
+ (libraries ocaml-vdom bindings)
+ (modes js)
+ (link_flags -no-check-prims))
+
+(rule
+ (targets main.js)
+ (deps main.bc.js)
+ (action
+  (run cp %{deps} %{targets})))
+
+(alias
+ (name DEFAULT)
+ (deps main.js index.html))

--- a/examples/tippy/index.html
+++ b/examples/tippy/index.html
@@ -1,0 +1,68 @@
+<html>
+  <head>    
+    <script src="https://unpkg.com/@popperjs/core@2"></script>
+    <script src="https://unpkg.com/tippy.js@6"></script>
+    <script src="main.js"></script>
+    <style>
+      html, body {
+        overflow: hidden;
+        height: 100%; 
+        width: 100%;
+        margin: 0;
+        padding: 0; 
+      }
+
+      div {
+        display: inline-block;
+      }
+
+      .root {
+        height: 100%; 
+        width: 100%;
+        padding: 10px;
+      }
+
+      .scrollable {
+        max-height: 100%;
+        max-width: 100%;
+        overflow: auto;
+      }
+
+      .column {       
+        display: flex;
+        flex-direction: column;
+        padding: 10px;
+      }
+
+      .row {        
+        display: flex;
+        flex-direction: row;
+      }
+
+      .tooltipable:hover {
+        text-decoration: underline;
+      }
+      
+      .tooltipable {        
+        cursor: pointer;
+      }
+    
+      p {
+        max-height: 200px !important;
+        padding: 15px;       
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      div[data-escaped], div[data-reference-hidden]  {
+        visibility: hidden;
+        opacity: 0;
+        pointer-events: none;
+      }
+    </style>    
+  </head>
+  <body>
+  </body>
+</html>

--- a/examples/tippy/main.ml
+++ b/examples/tippy/main.ml
@@ -1,0 +1,255 @@
+module V = Vdom
+
+let source =
+  [ "Bérénice", {|
+Ah ! cruel ! est-il temps de me le déclarer ?
+Qu’avez-vous fait ? Hélas ! je me suis crue aimée.
+Au plaisir de vous voir mon âme accoutumée
+Ne vit plus que pour vous. Ignoriez-vous vos lois
+Quand je vous l’avouai pour la première fois ?
+À quel excès d’amour m’avez-vous amenée ?
+Que ne me disiez-vous : « Princesse infortunée,
+Où vas-tu t’engager, et quel est ton espoir ?
+Ne donne point un cœur qu’on ne peut recevoir. »
+Ne l’avez-vous reçu, cruel, que pour le rendre,
+Quand de vos seules mains ce cœur voudrait dépendre ?
+Tout l’empire a vingt fois conspiré contre nous.
+Il était temps encor : que ne me quittiez-vous ?
+Mille raisons alors consolaient ma misère :
+Je pouvais de ma mort accuser votre père,
+Le peuple, le sénat, tout l’empire romain,
+Tout l’univers, plutôt qu’une si chère main.
+Leur haine, dès longtemps contre moi déclarée,
+M’avait à mon malheur dès longtemps préparée.
+Je n’aurais pas, Seigneur, reçu ce coup cruel
+Dans le temps que j’espère un bonheur immortel,
+Quand votre heureux amour peut tout ce qu’il désire,
+Lorsque Rome se tait, quand votre père expire,
+Lorsque tout l’univers fléchit à vos genoux,
+Enfin quand je n’ai plus à redouter que vous.
+|}
+  ; "Titus", {|
+Et c’est moi seul aussi qui pouvais me détruire.
+Je pouvais vivre alors et me laisser séduire ;
+Mon cœur se gardait bien d’aller dans l’avenir
+Chercher ce qui pouvait un jour nous désunir.
+Je voulais qu’à mes vœux rien ne fût invincible,
+Je n’examinais rien, j’espérais l’impossible.
+Que sais-je ? J’espérais de mourir à vos yeux,
+Avant que d’en venir à ces cruels adieux.
+Les obstacles semblaient renouveler ma flamme,
+Tout l’empire parlait, mais la gloire, Madame,
+Ne s’était point encor fait entendre à mon cœur
+Du ton dont elle parle au cœur d’un empereur.
+Je sais tous les tourments où ce dessein me livre,
+Je sens bien que sans vous je ne saurais plus vivre,
+Que mon cœur de moi-même est prêt à s’éloigner,
+Mais il ne s’agit plus de vivre, il faut régner.
+|}
+  ;"Bérénice", {|
+Eh bien ! régnez, cruel, contentez votre gloire :
+Je ne dispute plus. J’attendais, pour vous croire,
+Que cette même bouche, après mille serments
+D’un amour qui devait unir tous nos moments,
+Cette bouche, à mes yeux s’avouant infidèle,
+M’ordonnât elle-même une absence éternelle.
+Moi-même j’ai voulu vous entendre en ce lieu.
+Je n’écoute plus rien, et pour jamais : adieu...
+Pour jamais ! Ah, Seigneur ! songez-vous en vous-même
+Combien ce mot cruel est affreux quand on aime ?
+Dans un mois, dans un an, comment souffrirons-nous,
+Seigneur, que tant de mers me séparent de vous ?
+Que le jour recommence et que le jour finisse,
+Sans que jamais Titus puisse voir Bérénice,
+Sans que de tout le jour je puisse voir Titus ?
+Mais quelle est mon erreur, et que de soins perdus !
+L’ingrat, de mon départ consolé par avance,
+Daignera-t-il compter les jours de mon absence ?
+Ces jours si longs pour moi lui sembleront trop courts.
+|}
+  ;"Titus", {|
+Je n’aurai pas, madame, à compter tant de jours :
+J’espère que bientôt la triste renommée
+Vous fera confesser que vous étiez aimée.
+Vous verrez que Titus n’a pu, sans expirer…
+|}
+  ; "Bérénice", {|
+Ah, seigneur ! s’il est vrai, pourquoi nous séparer ?
+Je ne vous parle point d’un heureux hyménée.
+Rome à ne vous plus voir m’a-t-elle condamnée ?
+Pourquoi m’enviez-vous l’air que vous respirez ?
+|}
+  ; "Titus", {|
+Hélas ! vous pouvez tout, madame : demeurez ;
+Je n’y résiste point. Mais je sens ma faiblesse :
+Il faudra vous combattre et vous craindre sans cesse,
+Et sans cesse veiller à retenir mes pas,
+Que vers vous à toute heure entraînent vos appas.
+Que dis-je ? en ce moment mon cœur, hors de lui-même,
+S’oublie, et se souvient seulement qu’il vous aime.
+|}
+  ; "Bérénice", {|
+Eh bien, seigneur, eh bien, qu’en peut-il arriver ?
+Voyez-vous les Romains prêts à se soulever ?
+|}
+  ; "Titus", {|
+Et qui sait de quel œil ils prendront cette injure ?
+S’ils parlent, si les cris succèdent au murmure,
+Faudra-t-il par le sang justifier mon choix ?
+S’ils se taisent, madame, et me vendent leurs lois,
+À quoi m’exposez-vous ? Par quelle complaisance
+Faudra-t-il quelque jour payer leur patience ?
+Que n’oseront-ils point alors me demander ?
+Maintiendrai-je des lois que je ne puis garder ?
+|}
+  ;"Bérénice", {|
+Vous ne comptez pour rien les pleurs de Bérénice !
+|}
+  ;"Titus", {|
+Je les compte pour rien ! Ah ciel ! quelle injustice !
+|}
+  ;"Bérénice", {|
+Quoi ! pour d’injustes lois que vous pouvez changer,
+En d’éternels chagrins vous-même vous plonger !
+Rome a ses droits, seigneur : n’avez-vous pas les vôtres ?
+Ses intérêts sont-ils plus sacrés que les nôtres ?
+Dites, parlez.
+|}
+  ;"Titus", {|
+Hélas ! que vous me déchirez !
+|}
+  ;"Bérénice", {|
+Vous êtes empereur, seigneur, et vous pleurez !
+|}
+  ;"Titus", {|
+Oui, madame, il est vrai, je pleure, je soupire,
+Je frémis. Mais enfin, quand j’acceptai l’empire,
+Rome me fit jurer de maintenir ses droits :
+Je dois les maintenir. Déjà, plus d’une fois,
+Rome a de mes pareils exercé la constance.
+Ah ! si vous remontiez jusques à sa naissance,
+Vous les verriez toujours à ses ordres soumis :
+L’un, jaloux de sa foi, va chez les ennemis
+|}
+  ]
+  |> List.map (fun (name, txt) ->
+      name, String.split_on_char '\n' txt
+            |> List.map String.trim
+            |> List.filter ((<>) "")
+            |> List.map (fun line ->
+                String.split_on_char ' ' line
+              )
+    )
+
+
+type model = {
+  data: (string * string list list) list;
+  height: int;
+  width: int;
+}
+
+
+let shuffle l =
+  let a = Array.of_list l in
+  let n = Array.length a in
+  let swap i j =
+    let t = a.(i) in
+    a.(i) <- a.(j);
+    a.(j) <- t
+  in
+  for i = n - 1 downto 1 do
+    let j = Random.int i in
+    swap i j
+  done;
+  Array.to_list a
+
+let shuffle_model model =
+  shuffle model
+  |> List.map
+    (fun (name, lines) ->
+       name, shuffle lines
+             |> List.map shuffle
+    )
+
+type msg =
+  | Shuffle
+  | Clear
+  | Reset
+  | Resize of {width: int; height: int}
+
+let button msg label =
+  V.input ~a:[V.type_button; V.value label; V.onclick (fun _ -> msg)] []
+
+let span ?a x = V.elt ?a "div" [x]
+let t = V.text
+let br = V.elt "br" []
+let p = V.elt "p"
+
+let col ?(a = []) = V.elt "div" ~a:(V.add_class "column" a)
+let row ?(a = []) = V.elt "div" ~a:(V.add_class "row" a)
+
+let tooltip txt l =
+  V.div ~a:(V.add_class "tooltipable" []) (Register.Tippy.tooltip ~trigger:[Click] txt :: l)
+
+let render_paragraph lines =
+  p ~a:(V.add_class "scrollable" [])
+    (List.map (fun words ->
+         List.map (fun w ->
+             [ tooltip w [t w]
+             ; t " "
+             ]
+           ) words @ [ [ br ]] |> List.flatten
+       )  lines
+     |> List.flatten)
+
+let resize =
+  Register.Window.onresize
+    (fun _ ->
+       let open Js_browser in
+       let height = Window.inner_height window |> int_of_float in
+       let width = Window.inner_width window |> int_of_float in
+       Some (Resize {height; width})
+    )
+
+let view model =
+  let container =
+    if model.height > model.width then
+      col
+    else
+      row
+  in
+  V.div ~a:
+    (V.add_class "scrollable" (V.add_class "root" []))
+    ( resize :: col [button Shuffle "Shuffle !"; button Clear "Clear"; button Reset "Reset"; t (Printf.sprintf "h: %d w:%d" model.height model.width)] ::
+      List.map
+        (fun (name, txt) ->
+           container [
+             row [t name];
+             row [render_paragraph txt]
+           ]
+        ) model.data
+    )
+
+let init =
+  V.return
+    {
+      data = source;
+      height = 1;
+      width = 0
+    }
+
+let update model = function
+  | Shuffle -> V.return {model with data = shuffle_model model.data}
+  | Resize {width; height} -> V.return {model with height; width}
+  | Reset -> init
+  | Clear -> V.return { data = []; height = 1; width = 0}
+let app =
+  V.app ~init ~view ~update ()
+
+open Js_browser
+
+let run () =
+  let container = Document.body document in
+  ignore (Vdom_blit.run ~container app)
+
+let () = Window.set_onload window run

--- a/examples/tippy/main.ml
+++ b/examples/tippy/main.ml
@@ -1,7 +1,9 @@
 module V = Vdom
 
 let source =
-  [ "Bérénice", {|
+  [
+    ( "Bérénice",
+      {|
 Ah ! cruel ! est-il temps de me le déclarer ?
 Qu’avez-vous fait ? Hélas ! je me suis crue aimée.
 Au plaisir de vous voir mon âme accoutumée
@@ -28,7 +30,9 @@ Lorsque Rome se tait, quand votre père expire,
 Lorsque tout l’univers fléchit à vos genoux,
 Enfin quand je n’ai plus à redouter que vous.
 |}
-  ; "Titus", {|
+    );
+    ( "Titus",
+      {|
 Et c’est moi seul aussi qui pouvais me détruire.
 Je pouvais vivre alors et me laisser séduire ;
 Mon cœur se gardait bien d’aller dans l’avenir
@@ -46,7 +50,9 @@ Je sens bien que sans vous je ne saurais plus vivre,
 Que mon cœur de moi-même est prêt à s’éloigner,
 Mais il ne s’agit plus de vivre, il faut régner.
 |}
-  ;"Bérénice", {|
+    );
+    ( "Bérénice",
+      {|
 Eh bien ! régnez, cruel, contentez votre gloire :
 Je ne dispute plus. J’attendais, pour vous croire,
 Que cette même bouche, après mille serments
@@ -67,19 +73,25 @@ L’ingrat, de mon départ consolé par avance,
 Daignera-t-il compter les jours de mon absence ?
 Ces jours si longs pour moi lui sembleront trop courts.
 |}
-  ;"Titus", {|
+    );
+    ( "Titus",
+      {|
 Je n’aurai pas, madame, à compter tant de jours :
 J’espère que bientôt la triste renommée
 Vous fera confesser que vous étiez aimée.
 Vous verrez que Titus n’a pu, sans expirer…
 |}
-  ; "Bérénice", {|
+    );
+    ( "Bérénice",
+      {|
 Ah, seigneur ! s’il est vrai, pourquoi nous séparer ?
 Je ne vous parle point d’un heureux hyménée.
 Rome à ne vous plus voir m’a-t-elle condamnée ?
 Pourquoi m’enviez-vous l’air que vous respirez ?
 |}
-  ; "Titus", {|
+    );
+    ( "Titus",
+      {|
 Hélas ! vous pouvez tout, madame : demeurez ;
 Je n’y résiste point. Mais je sens ma faiblesse :
 Il faudra vous combattre et vous craindre sans cesse,
@@ -88,11 +100,15 @@ Que vers vous à toute heure entraînent vos appas.
 Que dis-je ? en ce moment mon cœur, hors de lui-même,
 S’oublie, et se souvient seulement qu’il vous aime.
 |}
-  ; "Bérénice", {|
+    );
+    ( "Bérénice",
+      {|
 Eh bien, seigneur, eh bien, qu’en peut-il arriver ?
 Voyez-vous les Romains prêts à se soulever ?
 |}
-  ; "Titus", {|
+    );
+    ( "Titus",
+      {|
 Et qui sait de quel œil ils prendront cette injure ?
 S’ils parlent, si les cris succèdent au murmure,
 Faudra-t-il par le sang justifier mon choix ?
@@ -102,26 +118,30 @@ Faudra-t-il quelque jour payer leur patience ?
 Que n’oseront-ils point alors me demander ?
 Maintiendrai-je des lois que je ne puis garder ?
 |}
-  ;"Bérénice", {|
+    );
+    ("Bérénice", {|
 Vous ne comptez pour rien les pleurs de Bérénice !
-|}
-  ;"Titus", {|
+|});
+    ("Titus", {|
 Je les compte pour rien ! Ah ciel ! quelle injustice !
-|}
-  ;"Bérénice", {|
+|});
+    ( "Bérénice",
+      {|
 Quoi ! pour d’injustes lois que vous pouvez changer,
 En d’éternels chagrins vous-même vous plonger !
 Rome a ses droits, seigneur : n’avez-vous pas les vôtres ?
 Ses intérêts sont-ils plus sacrés que les nôtres ?
 Dites, parlez.
 |}
-  ;"Titus", {|
+    );
+    ("Titus", {|
 Hélas ! que vous me déchirez !
-|}
-  ;"Bérénice", {|
+|});
+    ("Bérénice", {|
 Vous êtes empereur, seigneur, et vous pleurez !
-|}
-  ;"Titus", {|
+|});
+    ( "Titus",
+      {|
 Oui, madame, il est vrai, je pleure, je soupire,
 Je frémis. Mais enfin, quand j’acceptai l’empire,
 Rome me fit jurer de maintenir ses droits :
@@ -131,23 +151,16 @@ Ah ! si vous remontiez jusques à sa naissance,
 Vous les verriez toujours à ses ordres soumis :
 L’un, jaloux de sa foi, va chez les ennemis
 |}
+    );
   ]
   |> List.map (fun (name, txt) ->
-      name, String.split_on_char '\n' txt
-            |> List.map String.trim
-            |> List.filter ((<>) "")
-            |> List.map (fun line ->
-                String.split_on_char ' ' line
-              )
-    )
+      ( name,
+        String.split_on_char '\n' txt
+        |> List.map String.trim
+        |> List.filter (( <> ) "")
+        |> List.map (fun line -> String.split_on_char ' ' line) ))
 
-
-type model = {
-  data: (string * string list list) list;
-  height: int;
-  width: int;
-}
-
+type model = { data: (string * string list list) list; height: int; width: int }
 
 let shuffle l =
   let a = Array.of_list l in
@@ -165,86 +178,77 @@ let shuffle l =
 
 let shuffle_model model =
   shuffle model
-  |> List.map
-    (fun (name, lines) ->
-       name, shuffle lines
-             |> List.map shuffle
-    )
+  |> List.map (fun (name, lines) -> (name, shuffle lines |> List.map shuffle))
 
-type msg =
-  | Shuffle
-  | Clear
-  | Reset
-  | Resize of {width: int; height: int}
+type msg = Shuffle | Clear | Reset | Resize of { width: int; height: int }
 
 let button msg label =
-  V.input ~a:[V.type_button; V.value label; V.onclick (fun _ -> msg)] []
+  V.input ~a:[ V.type_button; V.value label; V.onclick (fun _ -> msg) ] []
 
-let span ?a x = V.elt ?a "div" [x]
+let span ?a x = V.elt ?a "div" [ x ]
+
 let t = V.text
+
 let br = V.elt "br" []
+
 let p = V.elt "p"
 
 let col ?(a = []) = V.elt "div" ~a:(V.add_class "column" a)
+
 let row ?(a = []) = V.elt "div" ~a:(V.add_class "row" a)
 
 let tooltip txt l =
-  V.div ~a:(V.add_class "tooltipable" []) (Register.Tippy.tooltip ~trigger:[Click] txt :: l)
+  V.div
+    ~a:(V.add_class "tooltipable" [])
+    (Register.Tippy.tooltip ~trigger:[ Click ] txt :: l)
 
 let render_paragraph lines =
-  p ~a:(V.add_class "scrollable" [])
-    (List.map (fun words ->
-         List.map (fun w ->
-             [ tooltip w [t w]
-             ; t " "
-             ]
-           ) words @ [ [ br ]] |> List.flatten
-       )  lines
-     |> List.flatten)
+  p
+    ~a:(V.add_class "scrollable" [])
+    (List.map
+       (fun words ->
+          List.map (fun w -> [ tooltip w [ t w ]; t " " ]) words @ [ [ br ] ]
+          |> List.flatten
+       )
+       lines
+     |> List.flatten
+    )
 
 let resize =
-  Register.Window.onresize
-    (fun _ ->
-       let open Js_browser in
-       let height = Window.inner_height window |> int_of_float in
-       let width = Window.inner_width window |> int_of_float in
-       Some (Resize {height; width})
-    )
+  Register.Window.onresize (fun _ ->
+      let open Js_browser in
+      let height = Window.inner_height window |> int_of_float in
+      let width = Window.inner_width window |> int_of_float in
+      Some (Resize { height; width }))
 
 let view model =
-  let container =
-    if model.height > model.width then
-      col
-    else
-      row
-  in
-  V.div ~a:
-    (V.add_class "scrollable" (V.add_class "root" []))
-    ( resize :: col [button Shuffle "Shuffle !"; button Clear "Clear"; button Reset "Reset"; t (Printf.sprintf "h: %d w:%d" model.height model.width)] ::
-      List.map
-        (fun (name, txt) ->
-           container [
-             row [t name];
-             row [render_paragraph txt]
-           ]
-        ) model.data
+  let container = if model.height > model.width then col else row in
+  V.div
+    ~a:(V.add_class "scrollable" (V.add_class "root" []))
+    (resize
+     :: col
+       [
+         button Shuffle "Shuffle !";
+         button Clear "Clear";
+         button Reset "Reset";
+         t (Printf.sprintf "h: %d w:%d" model.height model.width);
+       ]
+     :: List.map
+       (fun (name, txt) ->
+          container [ row [ t name ]; row [ render_paragraph txt ] ]
+       )
+       model.data
     )
 
-let init =
-  V.return
-    {
-      data = source;
-      height = 1;
-      width = 0
-    }
+let init = V.return { data = source; height = 1; width = 0 }
 
 let update model = function
-  | Shuffle -> V.return {model with data = shuffle_model model.data}
-  | Resize {width; height} -> V.return {model with height; width}
+  | Shuffle -> V.return { model with data = shuffle_model model.data }
+  | Resize { width; height } -> V.return { model with height; width }
   | Reset -> init
-  | Clear -> V.return { data = []; height = 1; width = 0}
-let app =
-  V.app ~init ~view ~update ()
+  | Clear -> V.return { data = []; height = 1; width = 0 }
+
+let app = V.app ~init ~view ~update ()
 
 open Js_browser
 

--- a/examples/tippy/register.ml
+++ b/examples/tippy/register.ml
@@ -1,0 +1,145 @@
+module Window = struct
+  open Js_browser
+
+  type kind =
+    | Resize
+
+  let key = function
+    | Resize -> "resize"
+
+  let kind = function
+    | Resize -> Event.Resize
+
+  type Vdom.Custom.event +=
+    | WindowEvent: Event.t -> Vdom.Custom.event
+
+  type Vdom.Custom.t +=
+    | WindowListener: kind -> Vdom.Custom.t
+
+  type listener = {
+    mutable last_id: int;
+    cancel: unit -> unit;
+    handlers: (int, Event.t -> unit) Hashtbl.t;
+  }
+
+  let onresize f : _ Vdom.vdom =
+    let handler = function
+      | WindowEvent ev -> f ev
+      | _ -> None
+    in
+    Vdom.custom ~a:[Vdom.oncustomevent handler] (WindowListener Resize)
+
+  let listeners = Hashtbl.create 2
+
+  let new_handler event handler =
+    let key = key event in
+    let listener =
+      match Hashtbl.find_opt listeners key with
+      | None ->
+          let handlers = Hashtbl.create 2 in
+          let callback ev =
+            Hashtbl.iter (fun _ f -> f ev) handlers
+          in
+          let cancel = Window.add_cancellable_event_listener window (kind event) callback true in
+          let listener = { cancel; handlers; last_id = 0 } in
+          Hashtbl.add listeners key listener;
+          listener
+      | Some listener -> listener
+    in
+    let id = listener.last_id in
+    listener.last_id <- id + 1;
+    Hashtbl.add listener.handlers id handler;
+    fun () ->
+      Hashtbl.remove listener.handlers id;
+      if Hashtbl.length listener.handlers = 0 then begin
+        Hashtbl.remove listeners key;
+        listener.cancel ()
+      end
+
+  let handler ~send event =
+    let dispose = new_handler event (fun x -> send (Vdom.custom_event (WindowEvent x))) in
+    let sync ct =
+      match ct with
+      | WindowListener kind -> kind = event
+      | _ -> false
+    in
+    let elt = Document.create_text_node document "" in
+    Vdom_blit.Custom.make ~dispose ~sync elt
+
+  let () =
+    let f ctx custom =
+      let send = Vdom_blit.Custom.send_event ctx in
+      match custom with
+      | WindowListener kind -> Some (handler ~send kind)
+      | _ -> None
+    in
+    Vdom_blit.(register (custom f))
+
+end
+
+module Tippy = struct
+
+  type trigger =
+    | MouseEnter
+    | Focus
+    | Focusin
+    | Click
+    | Manual
+
+  let string_of_trigger = function
+    | MouseEnter -> "mouseenter"
+    | Focus -> "focus"
+    | Focusin -> "focusin"
+    | Click -> "click"
+    | Manual -> "manual"
+
+  let string_of_triggers l =
+    String.concat " " (List.map string_of_trigger l)
+
+  type value = {
+    content: string;
+    trigger: trigger list option
+  }
+
+  type Vdom.Custom.t +=
+      Tippy of value
+
+  let tooltip ?trigger content : _ Vdom.vdom =
+    Vdom.custom (Tippy {content; trigger})
+
+  let handler ~parent value =
+    let inst =
+      Bindings.Tippy.create parent
+        { content = value.content
+        ; trigger = Option.map string_of_triggers value.trigger
+        }
+    in
+    let value = ref value in
+    let dispose () =
+      Bindings.Tippy.destroy inst
+    in
+    let sync ct =
+      match ct with
+      | Tippy new_value ->
+          if new_value <> !value then begin
+            value := new_value;
+            Bindings.Tippy.set_content inst new_value.content;
+            Bindings.Tippy.set_props inst { trigger = Option.map string_of_triggers new_value.trigger }
+          end;
+          true
+      | _ ->
+          false
+    in
+    let elt = Js_browser.(Document.create_text_node document "") in
+    Vdom_blit.Custom.make ~dispose ~sync elt
+
+  let () =
+    let f ctx attr =
+      let parent = Vdom_blit.Custom.parent ctx in
+      match attr with
+      | Tippy value -> Some (handler ~parent value)
+      | _ -> None
+    in
+    Vdom_blit.(register (custom f))
+
+end

--- a/lib/js_browser.mli
+++ b/lib/js_browser.mli
@@ -597,6 +597,18 @@ module Window: sig
   type interval_id
 
   val add_event_listener: t -> Event.kind -> (Event.t -> unit) -> bool -> unit
+  val add_cancellable_event_listener: t -> Event.kind -> (Event.t -> unit) -> bool -> (unit -> unit)
+  [@@js.custom
+    val add_event_listener_internal: t -> Event.kind -> Ojs.t -> bool -> unit
+    [@@js.call "addEventListener"]
+    val remove_event_listener_internal: t -> Event.kind -> Ojs.t -> bool -> unit
+    [@@js.call "removeEventListener"]
+    let add_cancellable_event_listener x k f c =
+      let f = Ojs.fun_to_js 1 (fun x -> f (Event.t_of_js x)) in
+      add_event_listener_internal x k f c;
+      fun () ->
+        remove_event_listener_internal x k f c
+                                                                                      ]
   val document: t -> Document.t
   val set_onload: t -> (unit -> unit) -> unit
   val set_interval: t -> (unit -> unit) -> int -> interval_id

--- a/lib/js_browser.mli
+++ b/lib/js_browser.mli
@@ -444,7 +444,18 @@ module Element : sig
 
   val has_child_nodes: t (* T *) -> bool [@@js.call]
   val add_event_listener: t (* T *) -> Event.kind -> (Event.t -> unit) -> bool -> unit
-
+  val add_cancellable_event_listener: t -> Event.kind -> (Event.t -> unit) -> bool -> (unit -> unit)
+  [@@js.custom
+    val add_event_listener_internal: t -> Event.kind -> Ojs.t -> bool -> unit
+    [@@js.call "addEventListener"]
+    val remove_event_listener_internal: t -> Event.kind -> Ojs.t -> bool -> unit
+    [@@js.call "removeEventListener"]
+    let add_cancellable_event_listener x k f c =
+      let f = Ojs.fun_to_js 1 (fun x -> f (Event.t_of_js x)) in
+      add_event_listener_internal x k f c;
+      fun () ->
+        remove_event_listener_internal x k f c
+                                                                                      ]
   val inner_text: t -> string
   val get_elements_by_tag_name: t -> string -> t array
   val get_elements_by_class_name: t -> string -> t array
@@ -608,7 +619,7 @@ module Window: sig
       add_event_listener_internal x k f c;
       fun () ->
         remove_event_listener_internal x k f c
-  ]
+                                                                                      ]
   val document: t -> Document.t
   val set_onload: t -> (unit -> unit) -> unit
   val set_interval: t -> (unit -> unit) -> int -> interval_id

--- a/lib/js_browser.mli
+++ b/lib/js_browser.mli
@@ -608,7 +608,7 @@ module Window: sig
       add_event_listener_internal x k f c;
       fun () ->
         remove_event_listener_internal x k f c
-                                                                                      ]
+  ]
   val document: t -> Document.t
   val set_onload: t -> (unit -> unit) -> unit
   val set_interval: t -> (unit -> unit) -> int -> interval_id

--- a/lib/vdom_blit.mli
+++ b/lib/vdom_blit.mli
@@ -71,8 +71,8 @@ val run:
     into a fixed fresh DOM container node. *)
 
 val dispose: ('model, 'msg) app -> unit
-(** Dispose all the resources attached to an application and
-    remove its container from the DOM. *)
+(** Dispose all the resources attached to an application.
+    If the container was provided on run, it is emptied on disposal, otherwise it is removed from the DOM. *)
 
 val dom: ('model, 'msg) app -> Js_browser.Element.t
 (** Returns the main DOM node that serves as the container for a Vdom

--- a/lib/vdom_blit.mli
+++ b/lib/vdom_blit.mli
@@ -20,7 +20,7 @@ module Custom: sig
   type t
   (** A controller for a custom element. *)
 
-  val make: sync:(Vdom.Custom.t -> bool) -> Js_browser.Element.t -> t
+  val make: ?dispose:(unit -> unit) -> sync:(Vdom.Custom.t -> bool) -> Js_browser.Element.t -> t
   (** Create a custom controller out of DOM element.
 
       The [sync] function is in charge of updating the internal state
@@ -31,6 +31,8 @@ module Custom: sig
 
   type ctx
   (** Context for custom element handlers. *)
+
+  val parent: ctx -> Js_browser.Element.t
 
   val send_event: ctx -> Vdom.event -> unit
   (** Can only be called after the handler returns (typically in a DOM event callback). *)

--- a/lib/vdom_blit.mli
+++ b/lib/vdom_blit.mli
@@ -70,6 +70,10 @@ val run:
 (** Instantion a VDOM application into a concrete one, running
     into a fixed fresh DOM container node. *)
 
+val dispose: ('model, 'msg) app -> unit
+(** Dispose all the resources attached to an application and
+    remove its container from the DOM. *)
+
 val dom: ('model, 'msg) app -> Js_browser.Element.t
 (** Returns the main DOM node that serves as the container for a Vdom
     application. *)


### PR DESCRIPTION
# Description 

This PR adds the ability to dispose custom elements when they are blitted out of the dom. 
Also it adds the possibility to access the parent of the custom element when instanciating the element. 

This allows to implement "subscription-like" listener (see the resize example). 
Our to add features that interect with the global states and requires to
install and then uninstall some stateful instance (see the tippy example). 

Note: it is possible to attach features on an empty text node if one does not want to mess with element tree (but beware not to attach any attribute that are not event handler). 

I think, this work very well. 

It is ready for ready for review @alainfrisch. 
