### PR TITLE
Fix Promise, Event and Document

### DIFF
--- a/lib/js_browser.mli
+++ b/lib/js_browser.mli
@@ -686,6 +686,16 @@ module Document: sig
   val query_selector_all: t -> string -> Element.t list [@@js.call]
 
   val remove_all_selection_ranges: t -> unit [@@js.call "getSelection().removeAllRanges"]
+
+  (** Document readState. See https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState *)  
+  type ready_state =
+    | Loading [@js "loading"]
+    | Interactive [@js "interactive"]
+    | Complete [@js "complete"]
+  [@@js.enum]
+
+  val ready_state: t -> ready_state [@@js.get]
+  val add_event_listener: t -> Event.kind -> (Event.t -> unit) -> bool -> unit [@@js.call]
 end
 
 module History : sig

--- a/lib/js_browser.mli
+++ b/lib/js_browser.mli
@@ -358,6 +358,9 @@ module Event : sig
     | NonStandard of string [@js.default]
   [@@js.enum]
 
+  val kind_to_js : kind -> Ojs.t
+  val kind_of_js : Ojs.t -> kind
+
   val target: t -> Ojs.t [@@js.get]
   val related_target: t -> Ojs.t option [@@js.get]
   val prevent_default: t -> unit [@@js.call]

--- a/lib/js_browser.mli
+++ b/lib/js_browser.mli
@@ -4,20 +4,25 @@
 
 (** {1 Bindings for the DOM and other client-side Javascript APIs} *)
 
-module Promise: sig
-  [@@@js.stop]
+module [@js.scope "Promise"] Promise: sig
   type 'a t
+
+  val t_of_js: (Ojs.t -> 'a) -> Ojs.t -> 'a t
+  val t_to_js: ('a -> Ojs.t) -> 'a t -> Ojs.t
+
+  val resolve: 'a -> 'a t [@@js.global] 
+
+  [@@@js.stop]
   val then_: ?error:(Ojs.t -> unit) -> success:('a -> unit) -> 'a t -> unit
+  val and_then: ?error:(Ojs.t -> unit) -> ('a -> 'b t) -> 'a t -> 'b t
   [@@@js.start]
 
   [@@@js.implem
-    type 'a t = (Ojs.t -> 'a) * Ojs.t
+    val then_: Ojs.t -> success:('a -> unit) -> error:(Ojs.t -> unit) option -> unit[@@js.call "then"]
+    let then_ ?error ~success t = then_ t ~success ~error
 
-    let t_of_js f x = (f, x)
-    val then_: Ojs.t -> success:(Ojs.t -> unit) -> error:(Ojs.t -> unit) option -> unit[@@js.call "then"]
-    let then_ ?error ~success (alpha_of_js, ojs) =
-      then_ ojs ~success:(fun x -> success (alpha_of_js x)) ~error
-  ]
+    val and_then : Ojs.t -> success:('a -> 'b t) -> error:(Ojs.t -> unit) option -> 'b t [@@js.call "then"]
+    let and_then ?error success t = and_then t ~success ~error  ]
 end
 
 module Storage : sig

--- a/lib/js_browser.mli
+++ b/lib/js_browser.mli
@@ -15,6 +15,7 @@ module [@js.scope "Promise"] Promise: sig
   [@@@js.stop]
   val then_: ?error:(Ojs.t -> unit) -> success:('a -> unit) -> 'a t -> unit
   val and_then: ?error:(Ojs.t -> unit) -> ('a -> 'b t) -> 'a t -> 'b t
+  val map : ('a -> 'b) -> 'a t -> 'b t
   [@@@js.start]
 
   [@@@js.implem
@@ -22,7 +23,11 @@ module [@js.scope "Promise"] Promise: sig
     let then_ ?error ~success t = then_ t ~success ~error
 
     val and_then : Ojs.t -> success:('a -> 'b t) -> error:(Ojs.t -> unit) option -> 'b t [@@js.call "then"]
-    let and_then ?error success t = and_then t ~success ~error  ]
+    let and_then ?error success t = and_then t ~success ~error
+
+    val map : Ojs.t -> ('a -> 'b) -> 'b t [@@js.call "then"]
+    let map f t = map t f
+  ]
 end
 
 module Storage : sig


### PR DESCRIPTION
Fixes https://github.com/LexiFi/gen_js_api/issues/178

Makes `'a Promise.t` to be usable outside of the repo. by exposing `t_of_js` and `t_to_js`. 
Adds `resolve`, `and_then` and `map` so that Js Promises can be chained/mapped.
Adds Document.add_event_listener so that events can be added to document. 
Fixes #55 